### PR TITLE
Restore OGM dashboard and cron wiring

### DIFF
--- a/backend/app/api/v1/endpoint_modules/ogm.py
+++ b/backend/app/api/v1/endpoint_modules/ogm.py
@@ -1,6 +1,11 @@
-from typing import Optional
+from datetime import datetime
+from html import escape
+from pathlib import Path
+from typing import Any, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
 from app.api.errors import PUBLIC_ERROR_RESPONSES
 from app.api.schemas import OGMHarvestFailuresResponse, OGMRepoSummariesResponse
@@ -9,6 +14,23 @@ from app.services.ogm_harvest.repository import OGMHarvestRepository
 
 router = APIRouter()
 ogm_repo = OGMHarvestRepository()
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR)) if TEMPLATES_DIR.exists() else None
+
+
+def _format_timestamp(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M UTC")
+    if isinstance(value, str):
+        try:
+            normalized = value.replace("Z", "+00:00")
+            parsed = datetime.fromisoformat(normalized)
+            return parsed.strftime("%Y-%m-%d %H:%M UTC")
+        except ValueError:
+            return value
+    return str(value)
 
 
 @router.get("/ogm/repos", response_model=OGMRepoSummariesResponse, responses=PUBLIC_ERROR_RESPONSES)
@@ -18,6 +40,104 @@ async def list_public_ogm_repos():
     """
     repos = await ogm_repo.list_public_repo_summaries()
     return create_response({"repos": repos})
+
+
+@router.get(
+    "/ogm/repos/dashboard",
+    include_in_schema=False,
+    response_class=HTMLResponse,
+)
+async def ogm_repo_dashboard(request: Request):
+    repos = await ogm_repo.list_public_repo_summaries()
+
+    dashboard_repos = []
+    total_harvested = 0
+    total_available = 0
+    repos_with_aardvark = 0
+    enabled_repos = 0
+    never_harvested = 0
+
+    for repo in repos:
+        harvested_count = int(repo.get("harvested_record_count") or 0)
+        available_count = int(repo.get("available_record_count") or 0)
+        unpublished_count = int(repo.get("unpublished_record_count") or 0)
+        has_aardvark = bool(repo.get("ogm_has_aardvark"))
+        enabled = bool(repo.get("ogm_enabled"))
+        last_harvest_completed = repo.get("last_crawl_completed_at")
+        hidden_count = max(harvested_count - available_count, 0)
+        other_hidden_count = max(hidden_count - unpublished_count, 0)
+        api_hidden_breakdown = []
+        if unpublished_count:
+            api_hidden_breakdown.append({"count": unpublished_count, "label": "unpublished"})
+        if other_hidden_count:
+            api_hidden_breakdown.append({"count": other_hidden_count, "label": "not yet synced"})
+
+        total_harvested += harvested_count
+        total_available += available_count
+        repos_with_aardvark += int(has_aardvark)
+        enabled_repos += int(enabled)
+        never_harvested += int(not bool(last_harvest_completed))
+
+        dashboard_repos.append(
+            {
+                **repo,
+                "display_last_commit_at": _format_timestamp(repo.get("last_commit_at")),
+                "display_last_harvest_at": _format_timestamp(last_harvest_completed),
+                "display_last_harvest_started_at": _format_timestamp(
+                    repo.get("last_crawl_started_at")
+                ),
+                "harvest_gap_count": hidden_count,
+                "api_hidden_breakdown": api_hidden_breakdown,
+            }
+        )
+
+    summary = {
+        "repo_count": len(dashboard_repos),
+        "enabled_repo_count": enabled_repos,
+        "repos_with_aardvark_count": repos_with_aardvark,
+        "never_harvested_count": never_harvested,
+        "harvested_record_count": total_harvested,
+        "available_record_count": total_available,
+    }
+
+    if templates is None:
+        rows = "".join(
+            (
+                "<tr>"
+                f"<td>{escape(str(repo.get('ogm_repo_name') or ''))}</td>"
+                f"<td>{escape(str(repo.get('display_last_commit_at') or '-'))}</td>"
+                f"<td>{escape(str(repo.get('display_last_harvest_at') or '-'))}</td>"
+                f"<td>{'yes' if repo.get('ogm_has_aardvark') else 'no'}</td>"
+                f"<td>{int(repo.get('harvested_record_count') or 0)}</td>"
+                f"<td>{int(repo.get('available_record_count') or 0)}</td>"
+                "</tr>"
+            )
+            for repo in dashboard_repos
+        )
+        return HTMLResponse(
+            (
+                "<!doctype html><html><head>"
+                "<title>OpenGeoMetadata Repository Dashboard</title>"
+                "</head>"
+                "<body><h1>OpenGeoMetadata Repository Dashboard</h1>"
+                "<p>Templates are unavailable, showing a minimal fallback view.</p>"
+                "<table><thead><tr>"
+                "<th>Repository</th><th>Last commit</th><th>Last harvest</th>"
+                "<th>Aardvark</th><th>Harvested</th><th>Available</th>"
+                f"</tr></thead><tbody>{rows}</tbody></table></body></html>"
+            )
+        )
+
+    return templates.TemplateResponse(
+        "ogm_repo_dashboard.html",
+        {
+            "request": request,
+            "title": "OpenGeoMetadata Repository Dashboard",
+            "summary": summary,
+            "repos": dashboard_repos,
+            "generated_at": _format_timestamp(datetime.utcnow()),
+        },
+    )
 
 
 @router.get(

--- a/backend/tests/api/v1/test_ogm_public_endpoints.py
+++ b/backend/tests/api/v1/test_ogm_public_endpoints.py
@@ -35,6 +35,45 @@ def test_public_ogm_repos_endpoint_returns_repo_summaries():
     assert data["repos"] == sample_repos
 
 
+def test_public_ogm_repo_dashboard_renders_html_monitor():
+    sample_repos = [
+        {
+            "ogm_repo_name": "edu.utexas",
+            "ogm_repo_full_name": "OpenGeoMetadata/edu.utexas",
+            "ogm_github_url": "https://github.com/OpenGeoMetadata/edu.utexas",
+            "ogm_enabled": True,
+            "ogm_watch_mode": "nightly",
+            "ogm_has_aardvark": True,
+            "last_commit_at": "2026-02-26T03:15:16Z",
+            "last_commit_sha": "abc123def4567890",
+            "last_crawl_started_at": "2026-02-25T14:57:16.327086",
+            "last_crawl_completed_at": "2026-02-25T14:58:11.946192",
+            "last_crawl_status": "success",
+            "last_run_id": 142,
+            "harvested_success_count": 876,
+            "harvested_failure_count": 0,
+            "harvested_record_count": 904,
+            "available_record_count": 901,
+            "unpublished_record_count": 3,
+        }
+    ]
+
+    with patch(
+        "app.api.v1.endpoint_modules.ogm.ogm_repo.list_public_repo_summaries",
+        new_callable=AsyncMock,
+    ) as mock_summaries:
+        mock_summaries.return_value = sample_repos
+        response = client.get("/api/v1/ogm/repos/dashboard")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert "OGM Repository Monitor" in response.text
+    assert "edu.utexas" in response.text
+    assert "OpenGeoMetadata/edu.utexas" in response.text
+    assert "/api/v1/ogm/repos" in response.text
+    assert "3 unpublished" in response.text
+
+
 def test_public_ogm_failures_endpoint_lists_failed_runs():
     sample_failures = [
         {


### PR DESCRIPTION
## Summary
- restore the public `/api/v1/ogm/repos/dashboard` HTML route that was dropped during the backend sync merge
- keep the current public response-model/error-contract wiring for the JSON OGM endpoints
- restore deployable Kamal cron support: `cron` role, `config/crontab`, Docker image cron runtime, and cron env export for OGM/GitHub variables
- keep the active nightly OGM scheduler as the existing GitHub Actions workflow, with the Kamal cron OGM harvest line gated by `OGM_NIGHTLY_CRON_ENABLED=false` to avoid duplicate harvest enqueueing
- add regression tests for the dashboard route, OGM scheduled-harvest selection, cron env rendering, and Kamal cron wiring

## Root Cause
The upstream backend import kept the `/api/v1/ogm/repos` and harvest failure JSON endpoints, but replaced the OGM endpoint module with a version that no longer registered the dashboard route. The template and repository summary data were still present, so the running app returned 404 only because the route was missing.

A second audit found the cron import was incomplete for this downstream: the cron scripts existed, but OGM was missing the root `config/crontab`, the Kamal `cron` role, and Docker runtime support needed to run cron in the production image.

## Validation
- `ruff check backend/app/api/v1/endpoint_modules/ogm.py backend/tests/api/v1/test_ogm_public_endpoints.py`
- `ruff check backend/scripts/render_cron_env.py backend/tests/scripts/test_render_cron_env.py backend/tests/test_kamal_deploy_config.py backend/tests/tasks/test_ogm_harvest_tasks.py backend/app/tasks/ogm_harvest.py backend/scripts/trigger_ogm_nightly_sync.py`
- `python -m pytest backend/tests/api/test_error_contracts.py backend/tests/api/v1/test_ogm_public_endpoints.py`
- `python -m pytest backend/tests/tasks/test_ogm_harvest_tasks.py backend/tests/scripts/test_render_cron_env.py backend/tests/test_kamal_deploy_config.py backend/tests/api/v1/test_ogm_public_endpoints.py`
- `curl -i http://localhost:8000/api/v1/ogm/repos/dashboard` returned `HTTP/1.1 200 OK` with `text/html`
- `curl -i http://localhost:8000/api/v1/ogm/repos` returned `HTTP/1.1 200 OK` JSON